### PR TITLE
Bump libraries to v23.08, modify cuda-version from conda, add CUDA 12 support, add Aqua.jl to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/site/
 Manifest.toml
 
 .CondaPkg*
+cufile.log

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,12 +1,12 @@
 channels = ["rapidsai", "nvidia", "conda-forge"]
 
 [deps]
-cudatoolkit = ">=11.2,<=11.8"
-cucim = "=23.06"
-cudf = "=23.06"
-cugraph = "=23.06"
-cuml = "=23.06"
-cusignal = "=23.06"
-cuspatial = "=23.06"
-cuxfilter = "=23.06"
+cudf = "=23.08"
+cuda-version = "=12.0.0"
+cuxfilter = "=23.08"
+cucim = "=23.08"
+cuspatial = "=23.08"
+cugraph = "=23.08"
+cusignal = "=23.08"
+cuml = "=23.08"
 python = ">=3.9,<=3.10"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+Aqua = "0.6"
 CUDA = "3, 4"
 CondaPkg = "0.2"
 MLJBase = "0.20, 0.21"
@@ -21,9 +22,10 @@ Tables = "1"
 julia = "1.8"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MLJBase", "MLJTestInterface"]
+test = ["Test", "Aqua", "MLJBase", "MLJTestInterface"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RAPIDS"
 uuid = "2764e59e-7dd7-4b2d-a28d-ce06411bac13"
 authors = ["tylerjthomas9 <tylerjthomas9@gmail.com>"]
-version = "0.3.4"
+version = "0.4.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/RAPIDS.jl
+++ b/src/RAPIDS.jl
@@ -9,7 +9,6 @@ using CUDA
 
 const PKG = "RAPIDS"
 
-# Temp warning for 
 if Base.VERSION <= v"1.8.3"
     warning_msg = """
     RAPIDS.jl does not work out of the box with Julia versions before v1.9.
@@ -37,6 +36,19 @@ if !CUDA.has_cuda_gpu()
     macro py(x...) end
 else
     @info "CUDA GPU Detected"
+
+    # verify that the cuda version is supported
+    cuda_version = CUDA.driver_version()
+    error_msg = """
+        Error: CUDA version $cuda_version is not supported. 
+        11.2 <= CUDA version <= 12.0
+    """
+    @assert (cuda_version >= v"11.2") && (cuda_version <= v"12.0")
+
+    # add cuda version to conda environment
+    using CondaPkg
+    CondaPkg.add("cuda-version"; version="=$cuda_version", resolve=false)
+
     using PythonCall
     const cucim = PythonCall.pynew()
     const cudf = PythonCall.pynew()

--- a/src/RAPIDS.jl
+++ b/src/RAPIDS.jl
@@ -66,7 +66,7 @@ else
     function __init__()
         PythonCall.pycopy!(cucim, pyimport("cucim"))
         PythonCall.pycopy!(cudf, pyimport("cudf"))
-        # PythonCall.pycopy!(cugraph, pyimport("cugraph"))
+        # PythonCall.pycopy!(cugraph, pyimport("cugraph")) https://github.com/tylerjthomas9/RAPIDS.jl/issues/37
         PythonCall.pycopy!(cuml, pyimport("cuml"))
         PythonCall.pycopy!(cusignal, pyimport("cusignal"))
         PythonCall.pycopy!(cuspatial, pyimport("cuspatial"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using CUDA
 
 if CUDA.functional()
+    using Aqua
     using MLJBase
     using MLJTestInterface
     using RAPIDS
@@ -11,6 +12,8 @@ if CUDA.functional()
     include("cudf.jl")
     include("cuml.jl")
     include("cuml_integration.jl")
+
+    Aqua.test_all(RAPIDS; ambiguities=false)
 else
     @warn "Skipping tests because a CUDA compatible GPU was not detected."
 end


### PR DESCRIPTION
I am not sure of the best way to install the CUDA 11/12 version automatically with CondaPkg.jl, so I added a check to verify the system's CUDA driver. 